### PR TITLE
docs(readme+docker): Added Docker file + explanation in README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:22.04
+
+# Always run as root (default in base image)
+USER root
+
+# Set noninteractive frontend to avoid prompts during install
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install development tools and dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    build-essential \
+    bison \
+    cmake \
+    curl \
+    wget \
+    python3 \
+    python3-pip \
+    ninja-build \
+    clang \
+    lld \
+    openjdk-11-jdk \
+    graphviz \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set default shell
+CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ source venv/bin/activate
 ### 6. Go into the `/home` directory and then clone Morpher V2
 ```
 cd /home && \ 
-git clone --recurse-submodules  https://github.com/vlad-nitu/morpher-v2.git && \
+git clone --recurse-submodules  https://github.com/ecolab-nus/morpher-v2.git && \
 cd morpher-v2
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,89 @@ Welcome to **Morpher**, an open-source framework that provides comprehensive sup
 https://github.com/ecolab-nus/morpher-v2/assets/12274945/c5e6f136-0051-4059-8f59-c6a788efc7d0
 
 
+# Docker container: Build and Run Guide for Morpher-v2
+
+###  1. Build Docker container and create an interactive shell into it
+```
+    sudo docker build -t morpher-ubuntu-22.04 .
+    sudo docker run --name morpher-ubuntu-22.04_container -it morpher-ubuntu-22.04
+```
+
+### 2. Move in `/home` directory
+```
+    cd /home
+```
+Install sbt
+echo "deb https://repo.scala-sbt.org/scalasbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
+curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add
+apt-get update
+apt-get install sbt
+deb https://repo.scala-sbt.org/scalasbt/debian /
+
+### 3. Install LLVM
+
+```
+git clone https://github.com/llvm/llvm-project.git
+cd llvm-project
+git checkout 99020b3c73c1e22fa388be8fd0c44391d40b3a38
+mkdir llvm-build && cd llvm-build
+cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=TRUE -DLLVM_TARGETS_TO_BUILD="X86" ../llvm
+make -j16
+	export PATH=/home/llvm-project/llvm-build/bin:$PATH
+```
+
+### 4. Install Verilator
+
+```
+apt-get install -y autoconf g++ libfl2 libfl-dev zlib1g-dev
+git clone https://github.com/verilator/verilator.git
+cd verilator
+git pull
+git checkout v4.110  
+autoconf
+./configure
+make -j16
+make install
+```
+
+### 5. Setup Python 
+```
+#  Since Python 3.8 is deprecated (i.e., can’t be installed w/ apt), we use python 3.10 instead
+apt install -y python3.10-venv
+python3 -m venv venv
+source venv/bin/activate	
+```
+ 
+### 6. Go into the `/home` directory and then clone Morpher V2
+```
+cd /home && \ 
+git clone --recurse-submodules  https://github.com/vlad-nitu/morpher-v2.git && \
+cd morpher-v2
+```
+
+### 7. Install dependencies
+
+```
+echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu focal main universe" | tee -a /etc/apt/sources.list
+apt -y install g++-7 
+pip install -r python_requirements.txt
+apt-get install -y gcc-multilib g++-multilib
+apt install -y build-essential 
+
+```
+
+### 8. Build Morpher v2
+```
+bash build_all.sh
+```
+ 
+### 9. Run Morpher v2 DEMO
+```
+	python -u run_morpher_llvm16.py morpher_benchmarks/array_add/array_add.c array_add
+```
 
 
-# Build and Run Guide for Morpher-v2
+# Locally: Build and Run Guide for Morpher-v2
 
 ## Prerequisites
 

--- a/run_morpher_llvm16.py
+++ b/run_morpher_llvm16.py
@@ -167,6 +167,8 @@ def main(csource, function, config= "config/default_config.yaml"):
       os.system('cp *_pillars_i.txt '+ARCHGEN_KERNEL+kernel+'_i.txt ')
       os.system('cp *_pillars_r.txt '+ARCHGEN_KERNEL+kernel+'_r.txt ')
       os.system('cp mapped_ii.txt '+ARCHGEN_KERNEL)
+      # Added by me
+      os.system('cp *.bin '+ SIMULATOR_KERNEL)  
     else:
       os.system('%s/build/src/cgra_xml_mapper -d %s_PartPredDFG.xml -x 4 -y 4 -j %s/json_arch/%s -i %d -m %d' % (MAPPER_HOME,kernel,MAPPER_HOME, json_arch, init_II, mapping_method))
   

--- a/run_morpher_llvm16.py
+++ b/run_morpher_llvm16.py
@@ -96,7 +96,7 @@ def main(csource, function, config= "config/default_config.yaml"):
     os.system('rm *.xml')
     os.system('rm *.dot')
     print('Generating IR..\n')
-    os.system('clang -D CGRA_COMPILER -target x86_64-unknown-linux-gnu -Wno-implicit-function-declaration -Wno-format -Wno-main-return-type -c -fno-jump-tables -emit-llvm -O2 -fno-tree-vectorize -fno-unroll-loops %s -S -o %s.ll'%(csourcefile,kernel))
+    os.system('clang -D CGRA_COMPILER -target x86_64-unknown-linux-gnu -Wno-implicit-function-declaration -Wno-format -Wno-main-return-type -c -emit-llvm -O2 -fno-tree-vectorize -fno-unroll-loops %s -S -o %s.ll'%(csourcefile,kernel))
     #os.system('clang -D CGRA_COMPILER -target x86_64-unknown-linux-gnu -Wno-implicit-function-declaration -Wno-format -Wno-main-return-type -c -emit-llvm -O2 -fno-vectorize -fno-slp-vectorize -fno-tree-vectorize -fno-inline -fno-unroll-loops %s -S -o %s.ll'%(csourcefile,kernel))
 
     print('Optimizing IR..\n')

--- a/run_morpher_llvm16.py
+++ b/run_morpher_llvm16.py
@@ -154,7 +154,7 @@ def main(csource, function, config= "config/default_config.yaml"):
       os.system('%s/build/src/cgra_xml_mapper -d %s_PartPredDFG.xml -x 4 -y 4 -j %s -i %d -t HyCUBE_4REG -m %d' % (MAPPER_HOME,kernel,json_arch, init_II, mapping_method))
 
       os.chdir(SIMULATOR_KERNEL)
-      os.system('rm *.bin')  
+      # os.system('rm *.bin')  
   
       os.chdir(MAPPER_KERNEL)
       os.system('cp *.bin '+ SIMULATOR_KERNEL)  

--- a/run_morpher_llvm16.py
+++ b/run_morpher_llvm16.py
@@ -99,8 +99,6 @@ def main(csource, function, config= "config/default_config.yaml"):
     os.system('clang -D CGRA_COMPILER -target x86_64-unknown-linux-gnu -Wno-implicit-function-declaration -Wno-format -Wno-main-return-type -c -fno-jump-tables -emit-llvm -O2 -fno-tree-vectorize -fno-unroll-loops %s -S -o %s.ll'%(csourcefile,kernel))
     #os.system('clang -D CGRA_COMPILER -target x86_64-unknown-linux-gnu -Wno-implicit-function-declaration -Wno-format -Wno-main-return-type -c -emit-llvm -O2 -fno-vectorize -fno-slp-vectorize -fno-tree-vectorize -fno-inline -fno-unroll-loops %s -S -o %s.ll'%(csourcefile,kernel))
 
-    print('Optimizing IR..\n')
-    os.system('opt -gvn -mem2reg -memdep -memcpyopt -lcssa -loop-simplify -licm -loop-deletion -indvars -simplifycfg -mergereturn -indvars  %s.ll -S -o %s_opt.ll' % (kernel,kernel))
 
     print('Generating DFG (%s_PartPredDFG.xml/dot) and data layout (%s_mem_alloc.txt)..\n' % (kernel,kernel))
     # Run in RELEASE (i.e., no DEBUG outputs)
@@ -109,6 +107,9 @@ def main(csource, function, config= "config/default_config.yaml"):
     # Run in DEBUG
     # TODO: remove debug run, uncomment the line above
     # os.system('opt -load %s/build/src/libdfggenPass.so -debug -fn %s -nobanks %d -banksize %d -type %s  -enable-new-pm=0 -dfggen %s_opt.ll -S -o %s_opt_instrument.ll' % (DFG_GEN_HOME,kernel,numberofbanks,banksize, dfg_type,kernel,kernel))
+
+    print('Optimizing IR..\n')
+    os.system('opt -gvn -mem2reg -memdep -memcpyopt -lcssa -loop-simplify -licm -loop-deletion -indvars -simplifycfg -mergereturn -indvars  %s.ll -S -o %s_opt.ll' % (kernel,kernel))
 
 
     os.system('dot -Tpdf %s_PartPredDFG.dot -o %s_PartPredDFG.pdf' % (kernel,kernel))

--- a/run_morpher_llvm16.py
+++ b/run_morpher_llvm16.py
@@ -103,8 +103,10 @@ def main(csource, function, config= "config/default_config.yaml"):
     os.system('opt -gvn -mem2reg -memdep -memcpyopt -lcssa -loop-simplify -licm -loop-deletion -indvars -simplifycfg -mergereturn -indvars  %s.ll -S -o %s_opt.ll' % (kernel,kernel))
 
     print('Generating DFG (%s_PartPredDFG.xml/dot) and data layout (%s_mem_alloc.txt)..\n' % (kernel,kernel))
-    os.system('opt -load %s/build/src/libdfggenPass.so -fn %s -nobanks %d -banksize %d -type %s  -enable-new-pm=0 -dfggen %s_opt.ll -S -o %s_opt_instrument.ll' % (DFG_GEN_HOME,kernel,numberofbanks,banksize, dfg_type,kernel,kernel))
-    #os.system('opt -load %s/build/src/libdfggenPass.so -debug -fn %s -nobanks %d -banksize %d -type %s  -enable-new-pm=0 -dfggen %s_opt.ll -S -o %s_opt_instrument.ll' % (DFG_GEN_HOME,kernel,numberofbanks,banksize, dfg_type,kernel,kernel))
+    # os.system('opt -load %s/build/src/libdfggenPass.so -fn %s -nobanks %d -banksize %d -type %s  -enable-new-pm=0 -dfggen %s_opt.ll -S -o %s_opt_instrument.ll' % (DFG_GEN_HOME,kernel,numberofbanks,banksize, dfg_type,kernel,kernel))
+    # Run in DEBUG
+    # TODO: remove debug run, uncomment the line above
+    os.system('opt -load %s/build/src/libdfggenPass.so -debug -fn %s -nobanks %d -banksize %d -type %s  -enable-new-pm=0 -dfggen %s_opt.ll -S -o %s_opt_instrument.ll' % (DFG_GEN_HOME,kernel,numberofbanks,banksize, dfg_type,kernel,kernel))
 
 
     os.system('dot -Tpdf %s_PartPredDFG.dot -o %s_PartPredDFG.pdf' % (kernel,kernel))

--- a/run_morpher_llvm16.py
+++ b/run_morpher_llvm16.py
@@ -96,7 +96,7 @@ def main(csource, function, config= "config/default_config.yaml"):
     os.system('rm *.xml')
     os.system('rm *.dot')
     print('Generating IR..\n')
-    os.system('clang -D CGRA_COMPILER -target x86_64-unknown-linux-gnu -Wno-implicit-function-declaration -Wno-format -Wno-main-return-type -c -emit-llvm -O2 -fno-tree-vectorize -fno-unroll-loops %s -S -o %s.ll'%(csourcefile,kernel))
+    os.system('clang -D CGRA_COMPILER -target x86_64-unknown-linux-gnu -Wno-implicit-function-declaration -Wno-format -Wno-main-return-type -c -fno-jump-tables -emit-llvm -O2 -fno-tree-vectorize -fno-unroll-loops %s -S -o %s.ll'%(csourcefile,kernel))
     #os.system('clang -D CGRA_COMPILER -target x86_64-unknown-linux-gnu -Wno-implicit-function-declaration -Wno-format -Wno-main-return-type -c -emit-llvm -O2 -fno-vectorize -fno-slp-vectorize -fno-tree-vectorize -fno-inline -fno-unroll-loops %s -S -o %s.ll'%(csourcefile,kernel))
 
     print('Optimizing IR..\n')

--- a/run_morpher_llvm16.py
+++ b/run_morpher_llvm16.py
@@ -103,10 +103,12 @@ def main(csource, function, config= "config/default_config.yaml"):
     os.system('opt -gvn -mem2reg -memdep -memcpyopt -lcssa -loop-simplify -licm -loop-deletion -indvars -simplifycfg -mergereturn -indvars  %s.ll -S -o %s_opt.ll' % (kernel,kernel))
 
     print('Generating DFG (%s_PartPredDFG.xml/dot) and data layout (%s_mem_alloc.txt)..\n' % (kernel,kernel))
-    # os.system('opt -load %s/build/src/libdfggenPass.so -fn %s -nobanks %d -banksize %d -type %s  -enable-new-pm=0 -dfggen %s_opt.ll -S -o %s_opt_instrument.ll' % (DFG_GEN_HOME,kernel,numberofbanks,banksize, dfg_type,kernel,kernel))
+    # Run in RELEASE (i.e., no DEBUG outputs)
+    os.system('opt -load %s/build/src/libdfggenPass.so -fn %s -nobanks %d -banksize %d -type %s  -enable-new-pm=0 -dfggen %s_opt.ll -S -o %s_opt_instrument.ll' % (DFG_GEN_HOME,kernel,numberofbanks,banksize, dfg_type,kernel,kernel))
+
     # Run in DEBUG
     # TODO: remove debug run, uncomment the line above
-    os.system('opt -load %s/build/src/libdfggenPass.so -debug -fn %s -nobanks %d -banksize %d -type %s  -enable-new-pm=0 -dfggen %s_opt.ll -S -o %s_opt_instrument.ll' % (DFG_GEN_HOME,kernel,numberofbanks,banksize, dfg_type,kernel,kernel))
+    # os.system('opt -load %s/build/src/libdfggenPass.so -debug -fn %s -nobanks %d -banksize %d -type %s  -enable-new-pm=0 -dfggen %s_opt.ll -S -o %s_opt_instrument.ll' % (DFG_GEN_HOME,kernel,numberofbanks,banksize, dfg_type,kernel,kernel))
 
 
     os.system('dot -Tpdf %s_PartPredDFG.dot -o %s_PartPredDFG.pdf' % (kernel,kernel))

--- a/run_morpher_llvm16.py
+++ b/run_morpher_llvm16.py
@@ -99,6 +99,8 @@ def main(csource, function, config= "config/default_config.yaml"):
     os.system('clang -D CGRA_COMPILER -target x86_64-unknown-linux-gnu -Wno-implicit-function-declaration -Wno-format -Wno-main-return-type -c -fno-jump-tables -emit-llvm -O2 -fno-tree-vectorize -fno-unroll-loops %s -S -o %s.ll'%(csourcefile,kernel))
     #os.system('clang -D CGRA_COMPILER -target x86_64-unknown-linux-gnu -Wno-implicit-function-declaration -Wno-format -Wno-main-return-type -c -emit-llvm -O2 -fno-vectorize -fno-slp-vectorize -fno-tree-vectorize -fno-inline -fno-unroll-loops %s -S -o %s.ll'%(csourcefile,kernel))
 
+    print('Optimizing IR..\n')
+    os.system('opt -gvn -mem2reg -memdep -memcpyopt -lcssa -loop-simplify -licm -loop-deletion -indvars -simplifycfg -mergereturn -indvars  %s.ll -S -o %s_opt.ll' % (kernel,kernel))
 
     print('Generating DFG (%s_PartPredDFG.xml/dot) and data layout (%s_mem_alloc.txt)..\n' % (kernel,kernel))
     # Run in RELEASE (i.e., no DEBUG outputs)
@@ -107,9 +109,6 @@ def main(csource, function, config= "config/default_config.yaml"):
     # Run in DEBUG
     # TODO: remove debug run, uncomment the line above
     # os.system('opt -load %s/build/src/libdfggenPass.so -debug -fn %s -nobanks %d -banksize %d -type %s  -enable-new-pm=0 -dfggen %s_opt.ll -S -o %s_opt_instrument.ll' % (DFG_GEN_HOME,kernel,numberofbanks,banksize, dfg_type,kernel,kernel))
-
-    print('Optimizing IR..\n')
-    os.system('opt -gvn -mem2reg -memdep -memcpyopt -lcssa -loop-simplify -licm -loop-deletion -indvars -simplifycfg -mergereturn -indvars  %s.ll -S -o %s_opt.ll' % (kernel,kernel))
 
 
     os.system('dot -Tpdf %s_PartPredDFG.dot -o %s_PartPredDFG.pdf' % (kernel,kernel))


### PR DESCRIPTION
# Problem
I had a hard time building Morpher V2 on my local machine in the past days. I am not sure if I made any mistakes on the way, or if the README of Morpher v2 just became stale with time.

# Solution
I created a bare-bones Ubuntu 22.04 Docker container (required by Morpher v2, as stated in the README) and an augmentation to the README in which I explain how I managed to get Morpher v2 build locally in a Docker container (as Morpher v1 had a Docker container accompanying the artifact, whereas this was not the case for Morpher v2). Please find both the Dockerfile as well as the README-fix.md attached in this PR.

Feel free to merge it.
